### PR TITLE
Fix custom.txt error

### DIFF
--- a/source/spelling.py
+++ b/source/spelling.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # Tuesday, April 13, 2021, 2:10 PM
 # migrated to Python 3 and Alfred 5
-#Light rain and snow, mist 🌧   🌡️+34°F (feels +25°F, 92%) 🌬️→13mph 🌗 Tue Mar 14 08:39:42 2023
+# Light rain and snow, mist 🌧   🌡️+34°F (feels +25°F, 92%) 🌬️→13mph 🌗 Tue Mar 14 08:39:42 2023
 # W11Q1 – 73 ➡️ 291 – 307 ❇️ 57
 
 
@@ -20,7 +20,7 @@ if DICTIONARY == 'dictionaries/custom.txt':
 
 if not os.path.exists(CUSTOM_DIC_FOLDER):
     os.makedirs(CUSTOM_DIC_FOLDER)
-if not os.path.exists(CUSTOM_DIC_FILE):
+if os.path.exists('dictionaries/custom.txt') and not os.path.exists(CUSTOM_DIC_FILE):
     os.rename('dictionaries/custom.txt', CUSTOM_DIC_FILE)
 
 


### PR DESCRIPTION
Fix error
```
[19:26:27.149] ERROR: Phonetic Spelling[Script Filter] Code 1: Traceback (most recent call last):
  File "spelling.py", line 24, in <module>
    os.rename('dictionaries/custom.txt', CUSTOM_DIC_FILE)
FileNotFoundError: [Errno 2] No such file or directory: 'dictionaries/custom.txt' -> '~/Library/Application Support/Alfred/Workflow Data/giovanni.spelling/custom.txt'
```